### PR TITLE
Add evaluation run tagging functionality

### DIFF
--- a/.github/requirements/build_validation_requirements.txt
+++ b/.github/requirements/build_validation_requirements.txt
@@ -14,5 +14,6 @@ azure-ai-projects
 azure-ai-evaluation[remote]
 azure-monitor-opentelemetry==1.6.7
 azure-ai-inference
+requests>=2.25.0
 semantic-kernel[azure]
 semantic-kernel[all]

--- a/.github/requirements/execute_job_requirements.txt
+++ b/.github/requirements/execute_job_requirements.txt
@@ -10,5 +10,6 @@ azure-ai-projects
 azure-ai-inference[prompts]
 azure-mgmt-web>=7.3.1
 azure-mgmt-resource>=23.2.0
+requests>=2.25.0
 semantic-kernel[azure]
 semantic-kernel[all]

--- a/llmops/eval_experiments.py
+++ b/llmops/eval_experiments.py
@@ -5,10 +5,14 @@ import datetime
 import importlib
 import inspect
 import os
+import re
 import sys
-from typing import Optional
+from typing import Dict, Optional
 import logging
+import requests
 from dotenv import load_dotenv
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
 
 from llmops.experiment import load_experiment
 
@@ -23,6 +27,54 @@ logging.basicConfig(
     ]
 )
 logger = logging.getLogger(__name__)
+
+
+def extract_run_id(url):
+    """Extract run ID from Azure ML studio URL."""
+    match = re.search(r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', url)
+    return match.group(0) if match else None
+
+
+def update_run_tags(
+    subscription_id: str,
+    resource_group_name: str,
+    workspace_name: str,
+    workspace_location: str,
+    run_id: str,
+    tags: Dict[str, str],
+    credential: Optional[object] = None
+):
+    """Workaround to update tags since the SDK is not supporting it yet."""
+    try:
+        if credential is None:
+            credential = DefaultAzureCredential()
+
+        token = credential.get_token("https://management.azure.com/.default").token
+
+        url = (f"https://{workspace_location}.api.azureml.ms/history/v1.0"
+               f"/subscriptions/{subscription_id}"
+               f"/resourceGroups/{resource_group_name}"
+               f"/providers/Microsoft.MachineLearningServices"
+               f"/workspaces/{workspace_name}"
+               f"/runs/{run_id}")
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json"
+        }
+
+        payload = {
+            "tags": tags
+        }
+
+        response = requests.patch(url, headers=headers, json=payload)
+
+        if response.status_code != 200:
+            raise RuntimeError(f"API request failed with status {response.status_code}: {response.text}")
+        logger.info("Successfully updated tags for run ID: %s", run_id)
+
+    except Exception as e:
+        logger.error("Failed to update run tags: %s", str(e))
 
 
 def set_environment_variables(env_dict):
@@ -231,10 +283,55 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    prepare_and_execute(
+    project = None
+    if os.environ.get("AZURE_AI_PROJECT_CONNECTION_STRING"):
+        project = AIProjectClient.from_connection_string(
+            conn_str=os.environ["AZURE_AI_PROJECT_CONNECTION_STRING"],
+            credential=DefaultAzureCredential()
+        )
+
+    results = prepare_and_execute(
         exp_filename=args.experiment_config_file,
         base_path=args.base_path,
         env_name=args.environment_name,
         report_dir=args.report_dir,
         eval_to_exec=args.eval_to_exec,
     )
+
+    # Workaround: Apply tags to evaluation runs until SDK supports tagging natively
+    if project and results:
+        for res in results:
+            try:
+                if ("result" in res and "rows" in res["result"] and 
+                    len(res["result"]["rows"]) > 0 and
+                    "studio_url" in res["result"]):
+                    
+                    evaluation_tags = {}  # Add custom tags here as needed
+                    
+                    if "outputs" in res["result"]["rows"][0]:
+                        outputs = res["result"]["rows"][0]["outputs"]
+                        if isinstance(outputs, dict) and "model" in outputs:
+                            evaluation_tags["model"] = outputs["model"]
+                        elif hasattr(outputs, 'model'):
+                            evaluation_tags["model"] = outputs.model
+
+                    run_id = extract_run_id(res["result"]["studio_url"])
+                    if run_id:
+                        workspace_scope = project.scope
+                        update_run_tags(
+                            workspace_scope["subscription_id"],
+                            workspace_scope["resource_group_name"],
+                            workspace_scope["project_name"],
+                            "eastus2",
+                            run_id,
+                            evaluation_tags
+                        )
+                    else:
+                        logger.warning("Could not extract run ID from studio URL")
+            except Exception as e:
+                logger.error("Failed to apply tags to result: %s", str(e))
+    else:
+        if not project:
+            logger.info("Azure AI Project Client not initialized - skipping tagging")
+        if not results:
+            logger.info("No results to tag")

--- a/tests/test_tagging_functionality.py
+++ b/tests/test_tagging_functionality.py
@@ -1,0 +1,324 @@
+"""Tests for the tagging functionality in eval_experiments."""
+import pytest
+from unittest.mock import Mock, patch
+from llmops.eval_experiments import extract_run_id, update_run_tags
+
+
+class TestExtractRunId:
+    """Test cases for extract_run_id function."""
+
+    def test_extract_run_id_from_valid_url(self):
+        """Test extracting run ID from a valid Azure ML studio URL."""
+        url = "https://ml.azure.com/runs/12345678-1234-1234-1234-123456789abc?wsid=/subscriptions/..."
+        expected_id = "12345678-1234-1234-1234-123456789abc"
+        
+        result = extract_run_id(url)
+        
+        assert result == expected_id
+
+    def test_extract_run_id_from_url_with_multiple_guids(self):
+        """Test extracting run ID when URL contains multiple GUIDs."""
+        url = "https://ml.azure.com/runs/12345678-1234-1234-1234-123456789abc/details/87654321-4321-4321-4321-cba987654321"
+        expected_id = "12345678-1234-1234-1234-123456789abc"
+        
+        result = extract_run_id(url)
+        
+        assert result == expected_id
+
+    def test_extract_run_id_from_invalid_url(self):
+        """Test extracting run ID from URL without valid GUID."""
+        url = "https://example.com/invalid-url"
+        
+        result = extract_run_id(url)
+        
+        assert result is None
+
+    def test_extract_run_id_from_empty_string(self):
+        """Test extracting run ID from empty string."""
+        url = ""
+        
+        result = extract_run_id(url)
+        
+        assert result is None
+
+
+class TestUpdateRunTags:
+    """Test cases for update_run_tags function."""
+
+    @patch('llmops.eval_experiments.requests.patch')
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_update_run_tags_success(self, mock_credential_class, mock_patch):
+        """Test successful tag update."""
+        mock_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "fake-token"
+        mock_credential.get_token.return_value = mock_token
+        mock_credential_class.return_value = mock_credential
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_patch.return_value = mock_response
+
+        subscription_id = "sub-123"
+        resource_group = "rg-test"
+        workspace_name = "ws-test"
+        workspace_location = "eastus2"
+        run_id = "12345678-1234-1234-1234-123456789abc"
+        tags = {"model": "gpt-4", "experiment": "test"}
+
+        update_run_tags(
+            subscription_id=subscription_id,
+            resource_group_name=resource_group,
+            workspace_name=workspace_name,
+            workspace_location=workspace_location,
+            run_id=run_id,
+            tags=tags
+        )
+
+        mock_patch.assert_called_once()
+        call_args = mock_patch.call_args
+        
+        expected_url = (
+            f"https://{workspace_location}.api.azureml.ms/history/v1.0"
+            f"/subscriptions/{subscription_id}"
+            f"/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.MachineLearningServices"
+            f"/workspaces/{workspace_name}"
+            f"/runs/{run_id}"
+        )
+        assert call_args[0][0] == expected_url
+        
+        expected_headers = {
+            "Authorization": "Bearer fake-token",
+            "Content-Type": "application/json"
+        }
+        assert call_args[1]["headers"] == expected_headers
+        
+        expected_payload = {"tags": tags}
+        assert call_args[1]["json"] == expected_payload
+
+    @patch('llmops.eval_experiments.requests.patch')
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_update_run_tags_api_failure(self, mock_credential_class, mock_patch):
+        """Test handling of API failure."""
+        mock_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "fake-token"
+        mock_credential.get_token.return_value = mock_token
+        mock_credential_class.return_value = mock_credential
+        
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        mock_patch.return_value = mock_response
+
+        subscription_id = "sub-123"
+        resource_group = "rg-test"
+        workspace_name = "ws-test"
+        workspace_location = "eastus2"
+        run_id = "12345678-1234-1234-1234-123456789abc"
+        tags = {"model": "gpt-4"}
+
+        update_run_tags(
+            subscription_id=subscription_id,
+            resource_group_name=resource_group,
+            workspace_name=workspace_name,
+            workspace_location=workspace_location,
+            run_id=run_id,
+            tags=tags
+        )
+
+        mock_patch.assert_called_once()
+
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_update_run_tags_with_custom_credential(self, mock_default_credential):
+        """Test using custom credential instead of default."""
+        custom_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "custom-token"
+        custom_credential.get_token.return_value = mock_token
+
+        with patch('llmops.eval_experiments.requests.patch') as mock_patch:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_patch.return_value = mock_response
+
+            update_run_tags(
+                subscription_id="sub-123",
+                resource_group_name="rg-test",
+                workspace_name="ws-test",
+                workspace_location="eastus2",
+                run_id="12345678-1234-1234-1234-123456789abc",
+                tags={"test": "value"},
+                credential=custom_credential
+            )
+
+            mock_default_credential.assert_not_called()
+            custom_credential.get_token.assert_called_once_with("https://management.azure.com/.default")
+
+
+class TestIntegrationWithResults:
+    """Test cases for the integration with evaluation results and tagging."""
+
+    @patch('llmops.eval_experiments.requests.patch')
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_tagging_with_model_in_result(self, mock_credential_class, mock_patch):
+        """Test that model information from result is properly added to tags."""
+        mock_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "fake-token"
+        mock_credential.get_token.return_value = mock_token
+        mock_credential_class.return_value = mock_credential
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_patch.return_value = mock_response
+
+        result_with_model = {
+            "result": {
+                "rows": [
+                    {
+                        "outputs": {
+                            "model": "gpt-4o-mini"
+                        }
+                    }
+                ],
+                "studio_url": "https://ml.azure.com/runs/12345678-1234-1234-1234-123456789abc?wsid=..."
+            }
+        }
+
+        evaluation_tags = {}
+        if "outputs" in result_with_model["result"]["rows"][0]:
+            outputs = result_with_model["result"]["rows"][0]["outputs"]
+            if isinstance(outputs, dict) and "model" in outputs:
+                evaluation_tags["model"] = outputs["model"]
+
+        run_id = extract_run_id(result_with_model["result"]["studio_url"])
+        
+        update_run_tags(
+            subscription_id="sub-123",
+            resource_group_name="rg-test",
+            workspace_name="ws-test",
+            workspace_location="eastus2",
+            run_id=run_id,
+            tags=evaluation_tags
+        )
+
+        mock_patch.assert_called_once()
+        call_args = mock_patch.call_args
+        sent_payload = call_args[1]["json"]
+        
+        assert "tags" in sent_payload
+        assert "model" in sent_payload["tags"]
+        assert sent_payload["tags"]["model"] == "gpt-4o-mini"
+
+    @patch('llmops.eval_experiments.requests.patch')
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_tagging_without_model_in_result(self, mock_credential_class, mock_patch):
+        """Test that tagging works gracefully when no model information is available."""
+        mock_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "fake-token"
+        mock_credential.get_token.return_value = mock_token
+        mock_credential_class.return_value = mock_credential
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_patch.return_value = mock_response
+
+        result_without_model = {
+            "result": {
+                "rows": [
+                    {
+                        "outputs": {
+                            "score": 0.85,
+                            "response": "Some evaluation result"
+                        }
+                    }
+                ],
+                "studio_url": "https://ml.azure.com/runs/87654321-4321-4321-4321-cba987654321?wsid=..."
+            }
+        }
+
+        evaluation_tags = {}
+        if "outputs" in result_without_model["result"]["rows"][0]:
+            outputs = result_without_model["result"]["rows"][0]["outputs"]
+            if isinstance(outputs, dict) and "model" in outputs:
+                evaluation_tags["model"] = outputs["model"]
+
+        run_id = extract_run_id(result_without_model["result"]["studio_url"])
+        
+        update_run_tags(
+            subscription_id="sub-123",
+            resource_group_name="rg-test", 
+            workspace_name="ws-test",
+            workspace_location="eastus2",
+            run_id=run_id,
+            tags=evaluation_tags
+        )
+
+        mock_patch.assert_called_once()
+        call_args = mock_patch.call_args
+        sent_payload = call_args[1]["json"]
+        
+        assert "tags" in sent_payload
+        assert sent_payload["tags"] == {}
+
+    @patch('llmops.eval_experiments.requests.patch')
+    @patch('llmops.eval_experiments.DefaultAzureCredential')
+    def test_tagging_with_model_as_attribute(self, mock_credential_class, mock_patch):
+        """Test that model information works when outputs.model is an attribute."""
+        mock_credential = Mock()
+        mock_token = Mock()
+        mock_token.token = "fake-token"
+        mock_credential.get_token.return_value = mock_token
+        mock_credential_class.return_value = mock_credential
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_patch.return_value = mock_response
+
+        mock_outputs = Mock()
+        mock_outputs.model = "gpt-3.5-turbo"
+        
+        result_with_model_attr = {
+            "result": {
+                "rows": [
+                    {
+                        "outputs": mock_outputs
+                    }
+                ],
+                "studio_url": "https://ml.azure.com/runs/11111111-2222-3333-4444-555555555555?wsid=..."
+            }
+        }
+
+        evaluation_tags = {}
+        if "outputs" in result_with_model_attr["result"]["rows"][0]:
+            outputs = result_with_model_attr["result"]["rows"][0]["outputs"]
+            if isinstance(outputs, dict) and "model" in outputs:
+                evaluation_tags["model"] = outputs["model"]
+            elif hasattr(outputs, 'model'):
+                evaluation_tags["model"] = outputs.model
+
+        run_id = extract_run_id(result_with_model_attr["result"]["studio_url"])
+        
+        update_run_tags(
+            subscription_id="sub-123",
+            resource_group_name="rg-test",
+            workspace_name="ws-test", 
+            workspace_location="eastus2",
+            run_id=run_id,
+            tags=evaluation_tags
+        )
+
+        mock_patch.assert_called_once()
+        call_args = mock_patch.call_args
+        sent_payload = call_args[1]["json"]
+        
+        assert "tags" in sent_payload
+        assert "model" in sent_payload["tags"]
+        assert sent_payload["tags"]["model"] == "gpt-3.5-turbo"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- Add extract_run_id() to parse Azure ML studio URLs
- Add update_run_tags() for REST API-based tag updates
- Integrate tagging into eval_experiments.py main workflow
- Add comprehensive tests
- Update CI/CD requirements for new dependencies
- Workaround until SDK supports native tagging